### PR TITLE
Changed error message to give more info to user

### DIFF
--- a/src/main/java/com/mservicetech/openapi/validation/OpenApiValidator.java
+++ b/src/main/java/com/mservicetech/openapi/validation/OpenApiValidator.java
@@ -41,6 +41,11 @@ public class OpenApiValidator {
     final String VALIDATOR_REQUEST_PARAMETER_MISSING = "ERR11001";
 
 
+    final String VALIDATOR_REQUEST_PARAMETER_PATH_MISSING = "ERR11108";
+    final String VALIDATOR_REQUEST_PARAMETER_HEADER_MISSING = "ERR11017";
+    final String VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING = "ERR11000";
+
+
     public String spec;
     public OpenApiHelper openApiHelper;
     public SchemaValidator schemaValidator;
@@ -203,7 +208,7 @@ public class OpenApiValidator {
             return result.getStatus();
         }
         if  (result.skippedParameters!=null && !result.skippedParameters.isEmpty()) {
-            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_MISSING, p.getName(), openApiOperation.getPathString().original()))
+            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_PATH_MISSING, p.getName(), openApiOperation.getPathString().original()))
                     .filter(s->s != null).findFirst().get();
         }
         return null;
@@ -253,7 +258,7 @@ public class OpenApiValidator {
             return result.getStatus();
         }
         if  (result.skippedParameters!=null && !result.skippedParameters.isEmpty()) {
-            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_MISSING, p.getName(), openApiOperation.getPathString().original()))
+            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING, p.getName(), openApiOperation.getPathString().original()))
                     .filter(s->s != null).findFirst().get();
         }
         return null;
@@ -281,7 +286,7 @@ public class OpenApiValidator {
             return Optional.ofNullable(result.getStatus());
         }
         if  (result.skippedParameters!=null && !result.skippedParameters.isEmpty()) {
-            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_MISSING, p.getName(), openApiOperation.getPathString().original()))
+            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_HEADER_MISSING, p.getName(), openApiOperation.getPathString().original()))
                     .filter(s->s != null).findFirst();
         }
         return Optional.ofNullable(null);
@@ -296,7 +301,7 @@ public class OpenApiValidator {
             return Optional.ofNullable(result.getStatus());
         }
         if  (result.skippedParameters!=null && !result.skippedParameters.isEmpty()) {
-            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_MISSING, p.getName(), openApiOperation.getPathString().original()))
+            return result.skippedParameters.stream().map(p-> new Status (VALIDATOR_REQUEST_PARAMETER_HEADER_MISSING, p.getName(), openApiOperation.getPathString().original()))
                     .filter(s->s != null).findFirst();
         }
         return Optional.ofNullable(null);

--- a/src/main/resources/status.yml
+++ b/src/main/resources/status.yml
@@ -433,7 +433,7 @@ ERR11000:
   statusCode: 400
   code: ERR11000
   message: VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING
-  description: Query parameter %s is required on path %s but not found in request.
+  description: Query parameter %s is required, but not found in request.
 ERR11001:
   statusCode: 400
   code: ERR11001
@@ -518,7 +518,7 @@ ERR11017:
   statusCode: 400
   code: ERR11017
   message: VALIDATOR_REQUEST_PARAMETER_HEADER_MISSING
-  description: Header parameter %s is required but missing.
+  description: Header parameter %s is required, but not found in request.
 ERR11018:
   statusCode: 400
   code: ERR11018

--- a/src/main/resources/status.yml
+++ b/src/main/resources/status.yml
@@ -518,7 +518,7 @@ ERR11017:
   statusCode: 400
   code: ERR11017
   message: VALIDATOR_REQUEST_PARAMETER_HEADER_MISSING
-  description: Header parameter %s is required on path %s but not found in request.
+  description: Header parameter %s is required but missing.
 ERR11018:
   statusCode: 400
   code: ERR11018

--- a/src/main/resources/status.yml
+++ b/src/main/resources/status.yml
@@ -566,7 +566,11 @@ ERR11107:
   code: ERR11107
   message: COMPRESSION_EXCEPTION
   description: Exception occurs during compression %s.
-
+ERR11108:
+  statusCode: 400
+  code: ERR11108
+  message: VALIDATOR_REQUEST_PARAMETER_PATH_MISSING
+  description: Path parameter %s is required on path %s but not found in request.
 
 # 11200 - 11299 light hybrid validation errors
 ERR11200:


### PR DESCRIPTION
Previous error message doesn't say which type parameter is missing

If I miss field MapKey, it Say this MapKey is required but doesn't say it's missed from HEADER or QUERY or PATH.


Fixed this bug.